### PR TITLE
feat:新增公告後會顯示到首頁

### DIFF
--- a/src/views/HomePage.vue
+++ b/src/views/HomePage.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { ref } from 'vue'
+import { ref, onMounted } from 'vue'
 import { useRouter } from 'vue-router'
 
 //按鈕相關
@@ -16,59 +16,20 @@ const link = ref([
   },
 ])
 
-//注意事項相關
-const rules = ref([
-  {
-    id: '1',
-    content:
-      '本系出借教室悉依據本校「場地設備收費標準及管理使用要點」(以下簡稱本校場地管理要點)辦理，可提供借用場地為',
-    addition:
-      '(1)G312會議室 (2)G313普通教室 (3)G314普通教室 (4)G325電腦教室 (5)G316電腦教室 (6)G501會議室 (7)G508系會議室 (8)G516電腦教室 (9)G506 IOS教室',
-  },
-  {
-    id: '2',
-    content:
-      '本校教學單位、行政單位申請借用場地時依據本校「場地管理要點」第十點：「(十四)」本校單位免費使用場地...」，餘依規定辦理借用申請，並依「附表四」進行收費。',
-    addition: ' ',
-  },
-  {
-    id: '3',
-    content: '借用教室請於借用日期10天前至資訊科學系辦公室確認檔期並遞送借用申請表。',
-    addition: ' ',
-  },
-  {
-    id: '4',
-    content:
-      '借用日期或時段如非周一至周五上課時段，須提前於上課時段至系辦借用教室鑰匙，並於次上課日上午8點錢將鑰匙歸還系辦',
-    addition: ' ',
-  },
-  {
-    id: '5',
-    content:
-      '使用普通教室資訊設備請於使用完畢後確認所有設備電源關閉，並關妥電源、空調、擦拭黑/白板並帶走垃圾後將前、後門上鎖再行離開。',
-    addition: ' ',
-  },
-  {
-    id: '6',
-    content: '本系如有特殊需要收回場地自行使用，得於使用7日前通知原申請單位，申請單位不得有異議。',
-    addition: ' ',
-  },
-  {
-    id: '7',
-    content: '其他未盡事項悉依本校場地管理要點辦理，如有違反要點及注意事項則日後不予出借。',
-    addition: ' ',
-  },
-  {
-    id: '8',
-    content: '須於使用日前至少一天完成借用申請。',
-    addition: ' ',
-  },
-  {
-    id: '9',
-    content: '開始使用本系統視同同意以上事項。',
-    addition: ' ',
-  },
-])
+const rules = ref([])
+
+const finalRule = {
+  id: 'final',
+  content: '開始使用本系統視同同意以上事項。',
+  addition: ' ',
+}
+
+onMounted(() => {
+  const saved = localStorage.getItem('rules')
+  if (saved) {
+    rules.value = JSON.parse(saved)
+  }
+})
 
 function changePage(link) {
   router.push({
@@ -102,18 +63,16 @@ const router = useRouter()
     <br />
     <h1>注意事項</h1>
     <hr />
-    <br />
-    <!-- 規則 -->
-    <div class="ruleIntro" v-for="rule in rules" :key="rule.id" :id="rule.id">
-      <div class="ruleSentence">
-        {{ rule.id }}.{{ rule.content }}<br />
-        <br />
-      </div>
 
-      <div class="ruleAddition" v-if="rule.addition != ' '">
-        {{ rule.addition }}<br />
-        <br />
-      </div>
+    <!-- 規則 -->
+    <div class="ruleIntro" v-for="(rule, index) in rules" :key="rule.id">
+      <div class="ruleSentence">{{ index + 1 }}. {{ rule.content }}<br /><br /></div>
+      <div class="ruleAddition" v-if="rule.addition.trim()">{{ rule.addition }}<br /><br /></div>
+    </div>
+
+    <!-- 永遠最後一條 -->
+    <div class="ruleIntro" :key="finalRule.id">
+      <div class="ruleSentence">{{ rules.length + 1 }}. {{ finalRule.content }}</div>
     </div>
 
     <div class="interval"></div>


### PR DESCRIPTION
## 描述

<!-- 請盡可能詳細地描述 -->
管理員在公告管理頁面新增或刪除公告的時候，首頁注意事項那邊也會更新


## 檢查清單

- [ ] 我已經在自己的電腦上測試過，確保功能已完整且程式能正常運行
- [ ] 我已在原始碼中添加註解，確保他人能理解我寫了什麼
- [ ] 我已經更新了文件／我的更改不需要更新文件
- [ ] 我的 PR 有清楚的標題與內容描述，也選取了標籤並連結相關的 GitHub Issues
- [ ] 這個分支是從最新的 `main` 上建立的 (如果不是，請先 rebase/merge 它)
