### PR TITLE
style:新增標題&改變排版，並將手機板的兩邊留一點空間

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -3,6 +3,7 @@ body {
   /* remove padding at the top of navbar */
   margin: 0;
   padding: 0;
+  background-color: #f6f6f5; /* 頁面背景顏色 */
 }
 /* 用 flex 讓 footer 能自然推到底 */
 #app {

--- a/src/views/BorrowRequestView.vue
+++ b/src/views/BorrowRequestView.vue
@@ -196,307 +196,317 @@ onMounted(() => {
 </script>
 
 <template>
-  <div class="form-container">
-    <h1>活動資訊</h1>
-    <hr style="width: 96%; margin: 0 auto" />
+  <div class="borrow-view">
+    <h1 style="padding: 0">借用申請</h1>
+    <hr />
+    <div class="form-container">
+      <h1>活動資訊</h1>
+      <hr style="width: 96%; margin: 0 auto" />
 
-    <!-- 活動名稱 & 活動人數 -->
-    <div class="row">
-      <div class="field">
-        <label>活動名稱</label>
-        <!-- v-model的意思是雙向綁定，當輸入框的值改變時，form.eventName也會隨之改變 -->
-        <input
-          v-model="form.eventName"
-          @input="() => validateField('eventName')"
-          placeholder="請填寫活動名稱"
-        />
-        <span class="error" v-if="errors.eventName">{{ errors.eventName }}</span>
+      <!-- 活動名稱 & 活動人數 -->
+      <div class="row">
+        <div class="field">
+          <label>活動名稱</label>
+          <!-- v-model的意思是雙向綁定，當輸入框的值改變時，form.eventName也會隨之改變 -->
+          <input
+            v-model="form.eventName"
+            @input="() => validateField('eventName')"
+            placeholder="請填寫活動名稱"
+          />
+          <span class="error" v-if="errors.eventName">{{ errors.eventName }}</span>
+        </div>
+
+        <div class="field">
+          <label>活動人數</label>
+          <!-- 輸入的只能是數字，或是旁邊箭頭只能是正整數加減，不能輸入中文 -->
+          <input
+            type="number"
+            v-model="form.peopleCount"
+            placeholder="請填寫活動人數"
+            @input="() => validateField('peopleCount')"
+          />
+          <span class="error" v-if="errors.peopleCount">{{ errors.peopleCount }}</span>
+        </div>
       </div>
 
+      <!-- 選擇教室 & 借用類型 -->
+      <div class="row">
+        <div class="field">
+          <label>選擇教室</label>
+          <select
+            @change="() => validateField('classroom')"
+            v-model="form.classroom"
+            :style="{ color: form.classroom === '' ? '#6c6c6c' : '#000' }"
+          >
+            <option value="">請選擇教室</option>
+            <option value="G312">G312 會議室</option>
+            <option value="G313">G313 普通教室</option>
+            <option value="G314">G314 普通教室</option>
+            <option value="G315">G315 電腦教室</option>
+            <option value="G316">G316 電腦教室</option>
+            <option value="G501">G501 會議室</option>
+            <option value="G508">G508 系圖書館</option>
+            <option value="G509">G509 IOS教室</option>
+            <option value="G516">G516 電腦教室</option>
+          </select>
+          <span class="error" v-if="errors.classroom">{{ errors.classroom }}</span>
+        </div>
+        <div class="field">
+          <label>借用類型</label>
+          <div>
+            <label>
+              <input
+                type="radio"
+                value="單次借用"
+                v-model="form.borrowType"
+                @change="() => validateField('borrowType')"
+              />
+              單次借用
+            </label>
+            <label>
+              <input
+                type="radio"
+                value="多次借用"
+                v-model="form.borrowType"
+                @change="() => validateField('borrowType')"
+              />
+              多次借用
+            </label>
+            <span class="error" v-if="errors.borrowType">{{ errors.borrowType }}</span>
+          </div>
+        </div>
+      </div>
+
+      <!-- 顯示多次借用的額外選項 -->
+      <div v-if="form.borrowType === '多次借用'" class="row">
+        <div class="field">
+          <label>頻率</label>
+          <select
+            v-model="form.repeatType"
+            @change="() => validateField('repeatType')"
+            :style="{ color: form.repeatType === '' ? '#6c6c6c' : '#000' }"
+          >
+            <option value="">請選擇頻率</option>
+            <option value="每天">每天</option>
+            <option value="每周">每周</option>
+          </select>
+          <span class="error" v-if="errors.repeatType">{{ errors.repeatType }}</span>
+        </div>
+
+        <div class="field">
+          <label>起始日期</label>
+          <input
+            type="date"
+            v-model="form.multiStartDate"
+            @input="() => validateField('multiStartDate')"
+            :style="{ color: form.multiStartDate === '' ? '#6c6c6c' : '#000' }"
+          />
+          <span class="error" v-if="errors.multiStartDate">{{ errors.multiStartDate }}</span>
+        </div>
+
+        <div class="field">
+          <label>結束日期</label>
+          <input
+            type="date"
+            v-model="form.multiEndDate"
+            @input="() => validateField('multiEndDate')"
+            :style="{ color: form.multiEndDate === '' ? '#6c6c6c' : '#000' }"
+          />
+          <span class="error" v-if="errors.multiEndDate">{{ errors.multiEndDate }}</span>
+        </div>
+      </div>
+
+      <!-- 日期 & 時間 -->
+      <div class="row">
+        <!-- 單次借用時顯示選擇日期 -->
+        <div class="field" v-if="form.borrowType !== '多次借用'">
+          <label>選擇日期</label>
+          <input
+            type="date"
+            v-model="form.date"
+            :style="{ color: form.date === '' ? '#6c6c6c' : '#000' }"
+            @input="() => validateField('date')"
+          />
+          <span class="error" v-if="errors.date">{{ errors.date }}</span>
+        </div>
+
+        <!-- 活動時間 -->
+        <div class="field">
+          <label>活動時間(起)</label>
+          <select
+            v-model="form.startTime"
+            @change="() => validateField('startTime')"
+            :style="{ color: form.startTime === '' ? '#6c6c6c' : '#000' }"
+          >
+            <option value="">請選取活動開始時段</option>
+            <option value="0810-0900">第 1 節 0810-0900</option>
+            <option value="0910-1000">第 2 節 0910-1000</option>
+            <option value="1010-1100">第 3 節 1010-1100</option>
+            <option value="1110-1200">第 4 節 1110-1200</option>
+            <option value="1210-1300">第 5 節 1210-1300</option>
+            <option value="1310-1400">第 6 節 1310-1400</option>
+            <option value="1410-1500">第 7 節 1410-1500</option>
+            <option value="1510-1600">第 8 節 1510-1600</option>
+            <option value="1610-1700">第 9 節 1610-1700</option>
+            <option value="1710-1800">第 10 節 1710-1800</option>
+            <option value="1810-1900">第 11 節 1810-1900</option>
+            <option value="1910-2000">第 12 節 1910-2000</option>
+            <option value="2010-2100">第 13 節 2010-2100</option>
+            <option value="2110-2200">第 14 節 2110-2200</option>
+          </select>
+          <span class="error" v-if="errors.startTime">{{ errors.startTime }}</span>
+        </div>
+        <div class="field">
+          <label>活動時間(迄)</label>
+          <select
+            v-model="form.endTime"
+            @change="() => validateField('endTime')"
+            :style="{ color: form.endTime === '' ? '#6c6c6c' : '#000' }"
+          >
+            <option value="">請選取活動結束時段</option>
+            <option value="0810-0900">第 1 節 0810-0900</option>
+            <option value="0910-1000">第 2 節 0910-1000</option>
+            <option value="1010-1100">第 3 節 1010-1100</option>
+            <option value="1110-1200">第 4 節 1110-1200</option>
+            <option value="1210-1300">第 5 節 1210-1300</option>
+            <option value="1310-1400">第 6 節 1310-1400</option>
+            <option value="1410-1500">第 7 節 1410-1500</option>
+            <option value="1510-1600">第 8 節 1510-1600</option>
+            <option value="1610-1700">第 9 節 1610-1700</option>
+            <option value="1710-1800">第 10 節 1710-1800</option>
+            <option value="1810-1900">第 11 節 1810-1900</option>
+            <option value="1910-2000">第 12 節 1910-2000</option>
+            <option value="2010-2100">第 13 節 2010-2100</option>
+            <option value="2110-2200">第 14 節 2110-2200</option>
+          </select>
+          <span class="error" v-if="errors.endTime">{{ errors.endTime }}</span>
+        </div>
+      </div>
+
+      <!-- 活動內容 -->
       <div class="field">
-        <label>活動人數</label>
-        <!-- 輸入的只能是數字，或是旁邊箭頭只能是正整數加減，不能輸入中文 -->
-        <input
-          type="number"
-          v-model="form.peopleCount"
-          placeholder="請填寫活動人數"
-          @input="() => validateField('peopleCount')"
-        />
-        <span class="error" v-if="errors.peopleCount">{{ errors.peopleCount }}</span>
+        <label>活動內容說明</label>
+        <textarea
+          v-model="form.description"
+          placeholder="請填寫活動內容說明"
+          @input="() => validateField('description')"
+        ></textarea>
+        <span class="error" v-if="errors.description">{{ errors.description }}</span>
       </div>
     </div>
 
-    <!-- 選擇教室 & 借用類型 -->
-    <div class="row">
-      <div class="field">
-        <label>選擇教室</label>
-        <select
-          @change="() => validateField('classroom')"
-          v-model="form.classroom"
-          :style="{ color: form.classroom === '' ? '#6c6c6c' : '#000' }"
-        >
-          <option value="">請選擇教室</option>
-          <option value="G312">G312 會議室</option>
-          <option value="G313">G313 普通教室</option>
-          <option value="G314">G314 普通教室</option>
-          <option value="G315">G315 電腦教室</option>
-          <option value="G316">G316 電腦教室</option>
-          <option value="G501">G501 會議室</option>
-          <option value="G508">G508 系圖書館</option>
-          <option value="G509">G509 IOS教室</option>
-          <option value="G516">G516 電腦教室</option>
-        </select>
-        <span class="error" v-if="errors.classroom">{{ errors.classroom }}</span>
+    <div class="form-container2">
+      <h1>基本資料</h1>
+      <hr style="width: 96%; margin: 0 auto" />
+
+      <!-- 借用人姓名 & 指導老師姓名 -->
+      <div class="row">
+        <div class="field">
+          <label>借用人姓名</label>
+          <!-- v-model的意思是雙向綁定，當輸入框的值改變時，form.eventName也會隨之改變 -->
+          <input
+            v-model="form.borrowerName"
+            placeholder="請填寫借用人姓名"
+            @input="() => validateField('borrowerName')"
+          />
+          <span class="error" v-if="errors.borrowerName">{{ errors.borrowerName }}</span>
+        </div>
+
+        <div class="field">
+          <label>指導老師姓名(單位代表)</label>
+          <input
+            v-model="form.teacherName"
+            placeholder="請填寫指導老師姓名"
+            @input="() => validateField('teacherName')"
+          />
+          <span class="error" v-if="errors.teacherName">{{ errors.teacherName }}</span>
+        </div>
       </div>
-      <div class="field">
-        <label>借用類型</label>
-        <div>
-          <label>
-            <input
-              type="radio"
-              value="單次借用"
-              v-model="form.borrowType"
-              @change="() => validateField('borrowType')"
-            />
-            單次借用
-          </label>
-          <label>
-            <input
-              type="radio"
-              value="多次借用"
-              v-model="form.borrowType"
-              @change="() => validateField('borrowType')"
-            />
-            多次借用
-          </label>
-          <span class="error" v-if="errors.borrowType">{{ errors.borrowType }}</span>
+
+      <!-- 借用人系級/服務單位 & 指導老師系所(單位) -->
+      <div class="row">
+        <div class="field">
+          <label>借用人系級/服務單位</label>
+          <input
+            v-model="form.borrowerDepartment"
+            placeholder="請填寫借用人系級/服務單位"
+            @input="() => validateField('borrowerDepartment')"
+          />
+          <span class="error" v-if="errors.borrowerDepartment">{{
+            errors.borrowerDepartment
+          }}</span>
+        </div>
+        <div class="field">
+          <label>指導老師系所(單位)</label>
+          <input
+            v-model="form.teacherDepartment"
+            placeholder="請填寫指導老師系所(單位)"
+            @input="() => validateField('teacherDepartment')"
+          />
+          <span class="error" v-if="errors.teacherDepartment">{{ errors.teacherDepartment }}</span>
+        </div>
+      </div>
+
+      <!-- 借用人Email & 指導老師Email -->
+      <div class="row">
+        <div class="field">
+          <label>借用人Email</label>
+          <input
+            v-model="form.borrowerEmail"
+            placeholder="請填寫借用人Email"
+            @input="() => validateField('borrowerEmail')"
+          />
+          <span class="error" v-if="errors.borrowerEmail">{{ errors.borrowerEmail }}</span>
+        </div>
+        <div class="field">
+          <label>指導老師(單位)Email</label>
+          <input
+            v-model="form.teacherEmail"
+            placeholder="請填寫指導老師(單位)Email"
+            @input="() => validateField('teacherEmail')"
+          />
+          <span class="error" v-if="errors.teacherEmail">{{ errors.teacherEmail }}</span>
+        </div>
+      </div>
+
+      <!-- 借用人聯絡電話 & 指導老師連絡電話 -->
+      <div class="row">
+        <div class="field">
+          <label>借用人聯絡電話</label>
+          <input
+            v-model="form.borrowerPhone"
+            placeholder="請填寫借用人聯絡電話"
+            @input="() => validateField('borrowerPhone')"
+          />
+          <span class="error" v-if="errors.borrowerPhone">{{ errors.borrowerPhone }}</span>
+        </div>
+        <div class="field">
+          <label>指導老師(單位)聯絡電話</label>
+          <input
+            v-model="form.teacherPhone"
+            placeholder="請填寫指導老師(單位)聯絡電話"
+            @input="() => validateField('teacherPhone')"
+          />
+          <span class="error" v-if="errors.teacherPhone">{{ errors.teacherPhone }}</span>
         </div>
       </div>
     </div>
-
-    <!-- 顯示多次借用的額外選項 -->
-    <div v-if="form.borrowType === '多次借用'" class="row">
-      <div class="field">
-        <label>頻率</label>
-        <select
-          v-model="form.repeatType"
-          @change="() => validateField('repeatType')"
-          :style="{ color: form.repeatType === '' ? '#6c6c6c' : '#000' }"
-        >
-          <option value="">請選擇頻率</option>
-          <option value="每天">每天</option>
-          <option value="每周">每周</option>
-        </select>
-        <span class="error" v-if="errors.repeatType">{{ errors.repeatType }}</span>
-      </div>
-
-      <div class="field">
-        <label>起始日期</label>
-        <input
-          type="date"
-          v-model="form.multiStartDate"
-          @input="() => validateField('multiStartDate')"
-          :style="{ color: form.multiStartDate === '' ? '#6c6c6c' : '#000' }"
-        />
-        <span class="error" v-if="errors.multiStartDate">{{ errors.multiStartDate }}</span>
-      </div>
-
-      <div class="field">
-        <label>結束日期</label>
-        <input
-          type="date"
-          v-model="form.multiEndDate"
-          @input="() => validateField('multiEndDate')"
-          :style="{ color: form.multiEndDate === '' ? '#6c6c6c' : '#000' }"
-        />
-        <span class="error" v-if="errors.multiEndDate">{{ errors.multiEndDate }}</span>
-      </div>
-    </div>
-
-    <!-- 日期 & 時間 -->
-    <div class="row">
-      <!-- 單次借用時顯示選擇日期 -->
-      <div class="field" v-if="form.borrowType !== '多次借用'">
-        <label>選擇日期</label>
-        <input
-          type="date"
-          v-model="form.date"
-          :style="{ color: form.date === '' ? '#6c6c6c' : '#000' }"
-          @input="() => validateField('date')"
-        />
-        <span class="error" v-if="errors.date">{{ errors.date }}</span>
-      </div>
-
-      <!-- 活動時間 -->
-      <div class="field">
-        <label>活動時間(起)</label>
-        <select
-          v-model="form.startTime"
-          @change="() => validateField('startTime')"
-          :style="{ color: form.startTime === '' ? '#6c6c6c' : '#000' }"
-        >
-          <option value="">請選取活動開始時段</option>
-          <option value="0810-0900">第 1 節 0810-0900</option>
-          <option value="0910-1000">第 2 節 0910-1000</option>
-          <option value="1010-1100">第 3 節 1010-1100</option>
-          <option value="1110-1200">第 4 節 1110-1200</option>
-          <option value="1210-1300">第 5 節 1210-1300</option>
-          <option value="1310-1400">第 6 節 1310-1400</option>
-          <option value="1410-1500">第 7 節 1410-1500</option>
-          <option value="1510-1600">第 8 節 1510-1600</option>
-          <option value="1610-1700">第 9 節 1610-1700</option>
-          <option value="1710-1800">第 10 節 1710-1800</option>
-          <option value="1810-1900">第 11 節 1810-1900</option>
-          <option value="1910-2000">第 12 節 1910-2000</option>
-          <option value="2010-2100">第 13 節 2010-2100</option>
-          <option value="2110-2200">第 14 節 2110-2200</option>
-        </select>
-        <span class="error" v-if="errors.startTime">{{ errors.startTime }}</span>
-      </div>
-      <div class="field">
-        <label>活動時間(迄)</label>
-        <select
-          v-model="form.endTime"
-          @change="() => validateField('endTime')"
-          :style="{ color: form.endTime === '' ? '#6c6c6c' : '#000' }"
-        >
-          <option value="">請選取活動結束時段</option>
-          <option value="0810-0900">第 1 節 0810-0900</option>
-          <option value="0910-1000">第 2 節 0910-1000</option>
-          <option value="1010-1100">第 3 節 1010-1100</option>
-          <option value="1110-1200">第 4 節 1110-1200</option>
-          <option value="1210-1300">第 5 節 1210-1300</option>
-          <option value="1310-1400">第 6 節 1310-1400</option>
-          <option value="1410-1500">第 7 節 1410-1500</option>
-          <option value="1510-1600">第 8 節 1510-1600</option>
-          <option value="1610-1700">第 9 節 1610-1700</option>
-          <option value="1710-1800">第 10 節 1710-1800</option>
-          <option value="1810-1900">第 11 節 1810-1900</option>
-          <option value="1910-2000">第 12 節 1910-2000</option>
-          <option value="2010-2100">第 13 節 2010-2100</option>
-          <option value="2110-2200">第 14 節 2110-2200</option>
-        </select>
-        <span class="error" v-if="errors.endTime">{{ errors.endTime }}</span>
-      </div>
-    </div>
-
-    <!-- 活動內容 -->
-    <div class="field">
-      <label>活動內容說明</label>
-      <textarea
-        v-model="form.description"
-        placeholder="請填寫活動內容說明"
-        @input="() => validateField('description')"
-      ></textarea>
-      <span class="error" v-if="errors.description">{{ errors.description }}</span>
-    </div>
+    <!-- 按鈕 -->
+    <button @click="submitForm">送出申請</button>
   </div>
-
-  <div class="form-container2">
-    <h1>基本資料</h1>
-    <hr style="width: 96%; margin: 0 auto" />
-
-    <!-- 借用人姓名 & 指導老師姓名 -->
-    <div class="row">
-      <div class="field">
-        <label>借用人姓名</label>
-        <!-- v-model的意思是雙向綁定，當輸入框的值改變時，form.eventName也會隨之改變 -->
-        <input
-          v-model="form.borrowerName"
-          placeholder="請填寫借用人姓名"
-          @input="() => validateField('borrowerName')"
-        />
-        <span class="error" v-if="errors.borrowerName">{{ errors.borrowerName }}</span>
-      </div>
-
-      <div class="field">
-        <label>指導老師姓名(單位代表)</label>
-        <input
-          v-model="form.teacherName"
-          placeholder="請填寫指導老師姓名"
-          @input="() => validateField('teacherName')"
-        />
-        <span class="error" v-if="errors.teacherName">{{ errors.teacherName }}</span>
-      </div>
-    </div>
-
-    <!-- 借用人系級/服務單位 & 指導老師系所(單位) -->
-    <div class="row">
-      <div class="field">
-        <label>借用人系級/服務單位</label>
-        <input
-          v-model="form.borrowerDepartment"
-          placeholder="請填寫借用人系級/服務單位"
-          @input="() => validateField('borrowerDepartment')"
-        />
-        <span class="error" v-if="errors.borrowerDepartment">{{ errors.borrowerDepartment }}</span>
-      </div>
-      <div class="field">
-        <label>指導老師系所(單位)</label>
-        <input
-          v-model="form.teacherDepartment"
-          placeholder="請填寫指導老師系所(單位)"
-          @input="() => validateField('teacherDepartment')"
-        />
-        <span class="error" v-if="errors.teacherDepartment">{{ errors.teacherDepartment }}</span>
-      </div>
-    </div>
-
-    <!-- 借用人Email & 指導老師Email -->
-    <div class="row">
-      <div class="field">
-        <label>借用人Email</label>
-        <input
-          v-model="form.borrowerEmail"
-          placeholder="請填寫借用人Email"
-          @input="() => validateField('borrowerEmail')"
-        />
-        <span class="error" v-if="errors.borrowerEmail">{{ errors.borrowerEmail }}</span>
-      </div>
-      <div class="field">
-        <label>指導老師(單位)Email</label>
-        <input
-          v-model="form.teacherEmail"
-          placeholder="請填寫指導老師(單位)Email"
-          @input="() => validateField('teacherEmail')"
-        />
-        <span class="error" v-if="errors.teacherEmail">{{ errors.teacherEmail }}</span>
-      </div>
-    </div>
-
-    <!-- 借用人聯絡電話 & 指導老師連絡電話 -->
-    <div class="row">
-      <div class="field">
-        <label>借用人聯絡電話</label>
-        <input
-          v-model="form.borrowerPhone"
-          placeholder="請填寫借用人聯絡電話"
-          @input="() => validateField('borrowerPhone')"
-        />
-        <span class="error" v-if="errors.borrowerPhone">{{ errors.borrowerPhone }}</span>
-      </div>
-      <div class="field">
-        <label>指導老師(單位)聯絡電話</label>
-        <input
-          v-model="form.teacherPhone"
-          placeholder="請填寫指導老師(單位)聯絡電話"
-          @input="() => validateField('teacherPhone')"
-        />
-        <span class="error" v-if="errors.teacherPhone">{{ errors.teacherPhone }}</span>
-      </div>
-    </div>
-  </div>
-  <!-- 按鈕 -->
-  <button @click="submitForm">送出申請</button>
 </template>
 
-<style>
-body {
-  background-color: #f6f6f5; /* 頁面背景顏色 */
-}
-</style>
-
 <style scoped>
+.borrow-view {
+  max-width: 1000px;
+  margin: 40px auto;
+  color: #666;
+}
+.borrow-view h1 {
+  font-size: 30px;
+  margin-bottom: 20px;
+}
+
 .error {
   color: red;
   font-size: 15px;
@@ -521,12 +531,6 @@ body {
   padding: 15px 15px 25px 15px;
   max-width: 1130px;
   font-family: Arial, sans-serif;
-}
-
-h1 {
-  color: #555;
-  margin-bottom: 5px;
-  padding: 0 0 10px 30px;
 }
 
 .row {
@@ -602,16 +606,15 @@ button:hover {
 
 /* 手機板樣式 */
 @media (max-width: 768px) {
+  .borrow-view h1 {
+    margin: 20px 15px;
+    font-size: 24px;
+  }
   .form-container,
   .form-container2 {
     margin-top: 20px;
     padding: 10px;
     max-width: 100%; /* 滿版寬度 */
-  }
-
-  h1 {
-    font-size: 20px;
-    padding: 0 0 10px 10px;
   }
 
   .row {


### PR DESCRIPTION
## 描述

<img width="2867" height="1532" alt="image" src="https://github.com/user-attachments/assets/d78923a4-4cbd-4b17-a28c-3eda72470bb5" />
改變排版，變成跟教室介紹一樣的寬度，比較整齊，手機板的兩邊也留一點空間


## 檢查清單

- [ ] 我已經在自己的電腦上測試過，確保功能已完整且程式能正常運行
- [ ] 我已在原始碼中添加註解，確保他人能理解我寫了什麼
- [ ] 我已經更新了文件／我的更改不需要更新文件
- [ ] 我的 PR 有清楚的標題與內容描述，也選取了標籤並連結相關的 GitHub Issues
- [ ] 這個分支是從最新的 `main` 上建立的 (如果不是，請先 rebase/merge 它)
