### PR TITLE
Feat/將借用表單分成三個階段

### DIFF
--- a/src/assets/main.css
+++ b/src/assets/main.css
@@ -14,4 +14,5 @@ body {
 /* 內容區塊撐開剩餘空間 */
 .main-content {
   flex: 1;
+  margin-top: 65px; /* 為固定 navbar 留出空間 */
 }

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -13,6 +13,7 @@ const links = [
 ]
 
 const isMobileMenuOpen = ref(false)
+const isScrolled = ref(false)
 
 const toggleMobileMenu = () => {
   isMobileMenuOpen.value = !isMobileMenuOpen.value
@@ -22,6 +23,10 @@ const closeMobileMenu = () => {
   isMobileMenuOpen.value = false
 }
 
+const handleScroll = () => {
+  isScrolled.value = window.scrollY > 10
+}
+
 // Lock body scroll while mobile menu open
 watch(isMobileMenuOpen, (val) => {
   if (typeof document !== 'undefined') {
@@ -29,24 +34,28 @@ watch(isMobileMenuOpen, (val) => {
   }
 })
 
-onUnmounted(() => {
-  if (typeof document !== 'undefined') {
-    document.body.style.overflow = ''
-  }
-})
-
-// Close on Escape key
 onMounted(() => {
-  const handler = (e) => {
+  // Close on Escape key
+  const escapeHandler = (e) => {
     if (e.key === 'Escape') closeMobileMenu()
   }
-  window.addEventListener('keydown', handler)
-  onUnmounted(() => window.removeEventListener('keydown', handler))
+  window.addEventListener('keydown', escapeHandler)
+
+  // Handle scroll for transparent background
+  window.addEventListener('scroll', handleScroll)
+
+  onUnmounted(() => {
+    window.removeEventListener('keydown', escapeHandler)
+    window.removeEventListener('scroll', handleScroll)
+    if (typeof document !== 'undefined') {
+      document.body.style.overflow = ''
+    }
+  })
 })
 </script>
 
 <template>
-  <nav class="navbar">
+  <nav class="navbar" :class="{ scrolled: isScrolled }">
     <div class="nav-brand">
       <RouterLink to="/" class="brand-link">
         <img :src="logo" alt="Logo" class="logo" />
@@ -95,9 +104,20 @@ onMounted(() => {
   background: var(--nav-bg);
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   margin: 0;
-  position: relative;
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 1000;
   /* backdrop-filter: blur(10px);
   -webkit-backdrop-filter: blur(10px); */
+  transition: background-color 0.3s ease, backdrop-filter 0.3s ease;
+}
+
+.navbar.scrolled {
+  --nav-bg: rgba(255, 255, 255, 0.5);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
 }
 
 .nav-brand .brand-link {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -109,15 +109,11 @@ onMounted(() => {
   left: 0;
   right: 0;
   z-index: 1000;
-  /* backdrop-filter: blur(10px);
-  -webkit-backdrop-filter: blur(10px); */
   transition: background-color 0.3s ease, backdrop-filter 0.3s ease;
 }
 
 .navbar.scrolled {
   --nav-bg: rgba(255, 255, 255, 0.5);
-  backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
 }
 
 .nav-brand .brand-link {

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -101,7 +101,9 @@ onMounted(() => {
   justify-content: space-between;
   padding: 0 1.25rem;
   min-height: 65px;
-  background: var(--nav-bg);
+  /* Background moved to ::before to avoid creating a containing block for
+     descendants with position: fixed when using filter/backdrop-filter */
+  background: transparent;
   border-bottom: 1px solid rgba(0, 0, 0, 0.1);
   margin: 0;
   position: fixed;
@@ -109,6 +111,19 @@ onMounted(() => {
   left: 0;
   right: 0;
   z-index: 1000;
+
+  /* transition remains for variable-based background via ::before */
+  transition: background-color 0.3s ease;
+}
+
+.navbar::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: var(--nav-bg);
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+  z-index: -1; /* behind navbar content but within its stacking context */
   transition:
     background-color 0.3s ease,
     backdrop-filter 0.3s ease;
@@ -234,7 +249,7 @@ onMounted(() => {
     transition:
       transform 0.45s cubic-bezier(0.4, 0, 0.2, 1),
       opacity 0.35s ease;
-    z-index: 100; /* over navbar */
+    z-index: 1100; /* over navbar (navbar is 1000) */
   }
 
   /* Slide starts visually from bottom edge of navbar (simulate by delaying part of motion) */

--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -109,7 +109,9 @@ onMounted(() => {
   left: 0;
   right: 0;
   z-index: 1000;
-  transition: background-color 0.3s ease, backdrop-filter 0.3s ease;
+  transition:
+    background-color 0.3s ease,
+    backdrop-filter 0.3s ease;
 }
 
 .navbar.scrolled {

--- a/src/views/BorrowRequestView.vue
+++ b/src/views/BorrowRequestView.vue
@@ -340,7 +340,7 @@ onMounted(() => {
       <div class="row">
         <div class="field">
           <label>借用類型</label>
-          <div>
+          <div class="radio-group">
             <label>
               <input
                 type="radio"
@@ -755,6 +755,14 @@ input[type='radio'] {
   align-items: center;
 }
 
+.radio-group {
+  display: flex !important;
+  flex-direction: row !important;
+  gap: 20px;
+  align-items: center;
+  flex-wrap: wrap;
+}
+
 .field div label {
   display: flex;
   align-items: center;
@@ -899,6 +907,14 @@ textarea {
     gap: 10px;
   }
 
+  /* 借用類型單選按鈕保持橫向排列 */
+  .radio-group {
+    flex-direction: row !important;
+    gap: 15px !important;
+    justify-content: flex-start;
+    align-items: center;
+  }
+
   .field div label {
     font-size: 18px;
   }
@@ -963,6 +979,14 @@ textarea {
     margin-bottom: 15px;
     max-width: 40px;
     min-width: 15px;
+  }
+
+  .radio-group {
+    gap: 12px !important;
+  }
+
+  .radio-group label {
+    font-size: 16px !important;
   }
 }
 </style>

--- a/src/views/BorrowRequestView.vue
+++ b/src/views/BorrowRequestView.vue
@@ -957,7 +957,6 @@ textarea {
   }
 }
 
-/* 小屏手機樣式 */
 @media (max-width: 480px) {
   .stage-indicator {
     margin: 15px auto;
@@ -992,7 +991,6 @@ textarea {
     font-size: 16px !important;
   }
 
-  /* 小屏幕上的導航按鈕 */
   .navigation-buttons {
     gap: 10px;
     padding: 0 15px;

--- a/src/views/BorrowRequestView.vue
+++ b/src/views/BorrowRequestView.vue
@@ -927,15 +927,18 @@ textarea {
   }
 
   .navigation-buttons {
-    flex-direction: column;
-    gap: 10px;
+    flex-direction: row;
+    gap: 15px;
     padding: 0 20px;
+    justify-content: center;
   }
 
   .navigation-buttons button {
     font-size: 16px;
-    padding: 12px 0;
+    padding: 12px 20px;
     min-width: auto;
+    flex: 1;
+    max-width: 150px;
   }
 }
 
@@ -987,6 +990,18 @@ textarea {
 
   .radio-group label {
     font-size: 16px !important;
+  }
+
+  /* 小屏幕上的導航按鈕 */
+  .navigation-buttons {
+    gap: 10px;
+    padding: 0 15px;
+  }
+
+  .navigation-buttons button {
+    font-size: 14px;
+    padding: 10px 15px;
+    max-width: 120px;
   }
 }
 </style>

--- a/src/views/BorrowRequestView.vue
+++ b/src/views/BorrowRequestView.vue
@@ -627,8 +627,10 @@ onMounted(() => {
   display: flex;
   justify-content: center;
   align-items: center;
-  margin: 40px 0;
+  margin: 40px auto;
   padding: 20px;
+  width: 100%;
+  max-width: 600px;
 }
 
 .stage-item {
@@ -636,6 +638,7 @@ onMounted(() => {
   flex-direction: column;
   align-items: center;
   text-align: center;
+  flex: 0 0 auto;
 }
 
 .stage-number {
@@ -666,6 +669,8 @@ onMounted(() => {
   font-size: 14px;
   color: #888;
   font-weight: bold;
+  white-space: nowrap;
+  text-align: center;
 }
 
 .stage-item.active .stage-title {
@@ -677,11 +682,13 @@ onMounted(() => {
 }
 
 .stage-divider {
-  width: 80px;
+  flex: 1;
   height: 2px;
   background-color: #e0e0e0;
-  margin: 0 20px;
+  margin: 0 15px;
   margin-bottom: 25px;
+  max-width: 180px;
+  min-width: 30px;
 }
 
 .form-container {
@@ -828,15 +835,33 @@ textarea {
   }
 
   .stage-indicator {
-    flex-direction: column;
-    gap: 15px;
-    margin: 20px 0;
+    margin: 20px auto;
+    padding: 10px 5px;
+    max-width: 400px;
+  }
+
+  .stage-item {
+    flex: 0 0 auto;
+  }
+
+  .stage-number {
+    width: 35px;
+    height: 35px;
+    font-size: 16px;
+    margin-bottom: 6px;
+  }
+
+  .stage-title {
+    font-size: 12px;
+    white-space: nowrap;
+    text-align: center;
   }
 
   .stage-divider {
-    width: 2px;
-    height: 30px;
-    margin: 0;
+    margin: 0 8px;
+    margin-bottom: 18px;
+    max-width: 60px;
+    min-width: 25px;
   }
 
   .form-container {
@@ -895,6 +920,49 @@ textarea {
     font-size: 16px;
     padding: 12px 0;
     min-width: auto;
+  }
+}
+
+/* 平板樣式 */
+@media (max-width: 1024px) and (min-width: 769px) {
+  .stage-indicator {
+    padding: 15px 10px;
+    max-width: 500px;
+  }
+
+  .stage-divider {
+    max-width: 120px;
+    min-width: 30px;
+    margin: 0 10px;
+    margin-bottom: 25px;
+  }
+}
+
+/* 小屏手機樣式 */
+@media (max-width: 480px) {
+  .stage-indicator {
+    margin: 15px auto;
+    padding: 8px 2px;
+    max-width: 300px;
+  }
+
+  .stage-number {
+    width: 30px;
+    height: 30px;
+    font-size: 14px;
+    margin-bottom: 4px;
+  }
+
+  .stage-title {
+    font-size: 10px;
+    text-align: center;
+  }
+
+  .stage-divider {
+    margin: 0 5px;
+    margin-bottom: 15px;
+    max-width: 40px;
+    min-width: 15px;
   }
 }
 </style>

--- a/src/views/introductionPage.vue
+++ b/src/views/introductionPage.vue
@@ -273,13 +273,22 @@ button:hover {
 }
 
 @media (max-width: 767px) {
-  .buttonGrid {
-    grid-template-columns: repeat(2, 1fr);
+  /* 調整整個 section 的 margin */
+  .introduction {
+    margin: 20px 15px;
   }
 
+  /* 按鈕網格改成 2 列*/
+  .buttonGrid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 10px;
+  }
+
+  /* 各教室區塊改成直式排列，間距縮小 */
   .classroomIntro {
     flex-direction: column;
     align-items: flex-start;
+    gap: 20px;
   }
 
   .classroomImage,
@@ -289,6 +298,23 @@ button:hover {
 
   .classroomImage img {
     width: 100%;
+    max-height: 300px;
+    object-fit: cover; /* 保持圖片比例 */
+  }
+
+  .classroomInfo h3 {
+    font-size: 24px;
+  }
+
+  .classroomInfo p,
+  .classroomInfo a,
+  .borrowBtn {
+    font-size: 14px;
+  }
+
+  /* 樓層平面圖區塊文字調整 */
+  .floorPlans h3 {
+    margin-bottom: 15px;
   }
 }
 </style>


### PR DESCRIPTION
## 描述

將借用表單分成三個階段
1. 基本借用資訊
2. 活動資訊
3. 聯絡資訊

<img width="1325" height="755" alt="image" src="https://github.com/user-attachments/assets/9a6ba273-4cca-423c-befd-eb3544667ff2" />

<img width="1277" height="664" alt="image" src="https://github.com/user-attachments/assets/1a3747da-5f63-4a11-89f9-3d0c848eca07" />

<img width="1350" height="773" alt="image" src="https://github.com/user-attachments/assets/b1bba894-c223-4dd2-964c-a0ea0672e92b" />

## 檢查清單

- [x] 我已經在自己的電腦上測試過，確保功能已完整且程式能正常運行
- [x] 我已在原始碼中添加註解，確保他人能理解我寫了什麼
- [x] 我已經更新了文件／我的更改不需要更新文件
- [x] 我的 PR 有清楚的標題與內容描述，也選取了標籤並連結相關的 GitHub Issues
- [x] 這個分支是從最新的 `main` 上建立的 (如果不是，請先 rebase/merge 它)
