### PR TITLE
Style/在 mobile navbar 新增關閉按鈕

### DIFF
--- a/src/components/NavBar.vue
+++ b/src/components/NavBar.vue
@@ -190,7 +190,8 @@ onMounted(() => {
   border: none;
   cursor: pointer;
   padding: 0;
-  z-index: 10;
+  z-index: 1200;
+  position: relative;
 }
 
 .hamburger-line {


### PR DESCRIPTION
## 描述

在 mobile navbar 新增關閉按鈕

<img width="322" height="718" alt="image" src="https://github.com/user-attachments/assets/b968f6da-7dc2-450c-96e7-831b3185cee5" />


## 檢查清單

- [x] 我已經在自己的電腦上測試過，確保功能已完整且程式能正常運行
- [x] 我已在原始碼中添加註解，確保他人能理解我寫了什麼
- [x] 我已經更新了文件／我的更改不需要更新文件
- [x] 我的 PR 有清楚的標題與內容描述，也選取了標籤並連結相關的 GitHub Issues
- [x] 這個分支是從最新的 `main` 上建立的 (如果不是，請先 rebase/merge 它)
