### PR TITLE
feat: 新增課表狀態顏色說明標籤

### DIFF
--- a/src/views/StatusPage.vue
+++ b/src/views/StatusPage.vue
@@ -390,9 +390,15 @@ function selectRoom(id) {
                     v-if="schedule[getDateKey(date)]?.[time]"
                     class="event"
                     :class="{
-                      pending: schedule[getDateKey(date)][time].status === '審核中',
-                      'teacher-approved': schedule[getDateKey(date)][time].status === '教師核准',
+                      /* 藍色：包含 '審核中' 和 '教師核准' */
+                      pending: ['審核中', '教師核准'].includes(
+                        schedule[getDateKey(date)][time].status,
+                      ),
+
+                      /* 綠色：已核准 */
                       approved: schedule[getDateKey(date)][time].status === '已預約',
+
+                      /* (選用) 課程專用樣式 */
                       course: schedule[getDateKey(date)][time].status === '課程使用',
                     }"
                   >
@@ -687,12 +693,6 @@ th.todayColumn::after {
   background-color: #e0f2fe; /* light blue */
   color: #0369a1;
   border-left: 3px solid #0ea5e9;
-}
-
-.event.teacher-approved {
-  background-color: #f3e8ff; /* light purple */
-  color: #7e22ce;
-  border-left: 3px solid #a855f7;
 }
 
 .event.approved {


### PR DESCRIPTION
## 描述

<!-- 請盡可能詳細地描述 -->
增加顏色標籤
<img width="1121" height="449" alt="image" src="https://github.com/user-attachments/assets/f3fa04a3-e968-4b41-924d-d5c525c31a1e" />


## 檢查清單

- [x] 我已經在自己的電腦上測試過，確保功能已完整且程式能正常運行
- [x] 我已在原始碼中添加註解，確保他人能理解我寫了什麼
- [x] 我已經更新了文件／我的更改不需要更新文件
- [x] 我的 PR 有清楚的標題與內容描述，也選取了標籤並連結相關的 GitHub Issues
- [x] 這個分支是從最新的 `main` 上建立的 (如果不是，請先 rebase/merge 它)
